### PR TITLE
New packaging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,4 @@ gem 'omnibus-software', github: 'opscode/omnibus-software'
 # Use Test Kitchen with Vagrant for converging the build environment
 gem 'test-kitchen',    '~> 1.2'
 gem 'kitchen-vagrant', '~> 0.14'
+gem 'facter', '~> 2.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.2.8)
     addressable (2.4.0)
     artifactory (2.3.2)
     aws-sdk (2.2.37)
@@ -73,6 +74,8 @@ GEM
     cleanroom (1.0.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
+    facter (2.4.6)
+      CFPropertyList (~> 2.2.6)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
@@ -184,6 +187,7 @@ PLATFORMS
 
 DEPENDENCIES
   berkshelf (~> 4.0)
+  facter (~> 2.4)
   kitchen-vagrant (~> 0.14)
   omnibus!
   omnibus-software!

--- a/config/projects/occi-server.rb
+++ b/config/projects/occi-server.rb
@@ -1,3 +1,5 @@
+require 'facter'
+
 name "occi-server"
 maintainer "Boris Parak <parak@cesnet.cz>"
 homepage "https://github.com/EGI-FCTF/rOCCI-server"
@@ -21,18 +23,23 @@ dependency "occi-server"
 # Version manifest file
 dependency "version-manifest"
 
+# facter
+dependency "facter"
+
 # add external (runtime) dependencies/services
-external_deps = if File.exists?('/etc/redhat-release')
-                  # we are on CentOS/SL
-                  deps = %w(httpd mod_ssl policycoreutils-python mod_security memcached git)
-                  deps.concat ['mod_passenger >= 5.0', 'passenger-devel >= 5.0']
-                  deps
-                else
-                  # we are in Debian/Ubuntu
-                  deps = %w(apache2 libapache2-modsecurity memcached git)
-                  deps << 'libapache2-mod-passenger (>= 5.0)'
-                  deps
-                end
+case Facter.value('operatingsystem')
+when 'Debian', 'Ubuntu'
+  # Ubuntu 12.04: 'deb https://oss-binaries.phusionpassenger.com/apt/passenger precise main'
+  # Ubuntu 14.04: 'deb https://oss-binaries.phusionpassenger.com/apt/passenger trusty main'
+  # Debian 7: 'deb https://oss-binaries.phusionpassenger.com/apt/passenger wheezy main'
+  # Debian 8: 'deb https://oss-binaries.phusionpassenger.com/apt/passenger jessie main'
+  external_deps = %w(apache2 libapache2-modsecurity memcached git)
+  external_deps.concat ['passenger (>= 4.0)', 'passenger-dev (>= 4.0)', 'libapache2-mod-passenger (>= 4.0)']
+when 'CentOS'
+  # Centos/Scientific Linux: https://oss-binaries.phusionpassenger.com/yum/definitions/el-passenger.repo
+  external_deps = %w(httpd mod_ssl policycoreutils-python mod_security memcached git)
+  external_deps.concat ['passenger >= 4.0', 'passenger-devel >= 4.0', 'mod_passenger >= 4.0']
+end
 external_deps.each { |ext_dep| runtime_dependency ext_dep }
 
 # tweaking package-specific options

--- a/config/projects/occi-server.rb
+++ b/config/projects/occi-server.rb
@@ -8,7 +8,7 @@ description "An OCCI translation layer for a multitude of Cloud Management Frame
 # Defaults to C:/occi-server on Windows
 # and /opt/occi-server on all other platforms
 install_dir "#{default_root}/#{name}"
-build_version "1.1.7"
+build_version "1.1.8"
 build_iteration 1
 
 override :rubygems, :version => '2.4.4'

--- a/config/software/facter.rb
+++ b/config/software/facter.rb
@@ -1,0 +1,8 @@
+name "facter"
+
+dependency "ruby"
+dependency "rubygems"
+
+build do
+  gem "install facter -n #{install_dir}/bin --no-rdoc --no-ri"
+end

--- a/package-scripts/occi-server/postinst
+++ b/package-scripts/occi-server/postinst
@@ -23,6 +23,9 @@ if [ "x${OPERATINGSYSTEM}" == "xCentOS" ]; then
 else
   APACHE_EXAMPLE_VH_DIR=/etc/apache2/sites-available
   APACHE_EXAMPLE_VH_FILE=$APACHE_EXAMPLE_VH_DIR/occi-ssl
+  if [ "x${OPERATINGSYSTEM}" = "xDebian" -a "x${LSBMAJDISTRELEASE}" \> "x7" ] || [ "x${OPERATINGSYSTEM}" = "xUbuntu" -a "x${LSBMAJDISTRELEASE}" \> "x13" ]; then
+    APACHE_EXAMPLE_VH_FILE=$APACHE_EXAMPLE_VH_FILE.conf
+  fi
   APACHE_ENVVARS_FILE=/etc/apache2/envvars
   APACHE_PASSENGER_CONF=/etc/apache2/mods-available/passenger.conf
 fi
@@ -80,9 +83,11 @@ ln -sf $DEST_DIR/embedded/app/rOCCI-server/etc $LINK_CONFIG_DIR || error_exit "C
 # add Apache2 VM examples
 mkdir -p $APACHE_EXAMPLE_VH_DIR || error_exit "Could not create $APACHE_EXAMPLE_VH_DIR"
 if [ -f "$APACHE_EXAMPLE_VH_FILE" ]; then
+  chmod o-rwx $APACHE_EXAMPLE_VH_FILE
   APACHE_EXAMPLE_VH_FILE=$APACHE_EXAMPLE_VH_FILE.new
 fi
 cp $DEST_DIR/embedded/app/rOCCI-server/examples/etc/apache2/sites-available/occi-ssl $APACHE_EXAMPLE_VH_FILE || error_exit "Could not create $APACHE_EXAMPLE_VH_FILE"
+chmod o-rwx $APACHE_EXAMPLE_VH_FILE
 
 # adapt A2 VH example to the current system
 # set real hostname
@@ -98,6 +103,12 @@ sed -i "s/rocci_server/occi_server/g" $APACHE_EXAMPLE_VH_FILE || error_exit "Cou
 DEST_DIR_ESCAPED=$(echo "$DEST_DIR" | sed -e 's/[\/&]/\\&/g')
 sed -i "s/\/opt\/rOCCI-server\/public/$DEST_DIR_ESCAPED\/embedded\/app\/rOCCI-server\/public/g" $APACHE_EXAMPLE_VH_FILE || error_exit "Could not adapt $APACHE_EXAMPLE_VH_FILE to local configuration"
 sed -i "s/#PassengerRuby \/path\/to\/your\/bin\/ruby/PassengerRuby $DEST_DIR_ESCAPED\/embedded\/bin\/ruby/g" $APACHE_EXAMPLE_VH_FILE || error_exit "Could not adapt $APACHE_EXAMPLE_VH_FILE to local configuration"
+
+# apache configuration syntax change for newer versions
+if [ "x${OPERATINGSYSTEM}" = "xDebian" -a "x${LSBMAJDISTRELEASE}" \> "x7" ] || [ "x${OPERATINGSYSTEM}" = "xCentOS" -a "x${OPERATINGSYSTEMMAJRELEASE}" \> "x6" ] || [ "x${OPERATINGSYSTEM}" = "xUbuntu" -a "x${LSBMAJDISTRELEASE}" \> "x13" ]; then
+  sed -i 's/Allow from all/&\n\tRequire all granted/' $APACHE_EXAMPLE_VH_FILE || error_exit "Could not adapt $APACHE_EXAMPLE_VH_FILE to local configuration"
+  sed -i 's/#+LegacyDNStringFormat/+LegacyDNStringFormat/' $APACHE_EXAMPLE_VH_FILE || error_exit "Could not adapt $APACHE_EXAMPLE_VH_FILE to local configuration"
+fi
 
 # point apache2 to our runtime dir
 grep $APACHE_ENVVARS_FILE -e 'PASSENGER_NATIVE_SUPPORT_OUTPUT_DIR' &>/dev/null

--- a/package-scripts/occi-server/postinst
+++ b/package-scripts/occi-server/postinst
@@ -9,8 +9,13 @@ INSTALLER_DIR=`dirname $0`
 DEST_DIR=/opt/occi-server
 LINK_CONFIG_DIR=/etc/occi-server
 LINK_DEST_DIR=/opt/rOCCI-server
+FACTER_BINARY=/opt/occi-server/bin/facter
 
-if [ -f "/etc/redhat-release" ]; then
+OPERATINGSYSTEM=`${FACTER_BINARY} operatingsystem`
+LSBMAJDISTRELEASE=`${FACTER_BINARY} lsbmajdistrelease`
+OPERATINGSYSTEMMAJRELEASE=`${FACTER_BINARY} operatingsystemmajrelease`
+
+if [ "x${OPERATINGSYSTEM}" == "xCentOS" ]; then
   APACHE_EXAMPLE_VH_DIR=/etc/httpd/conf.d
   APACHE_EXAMPLE_VH_FILE=$APACHE_EXAMPLE_VH_DIR/occi-ssl.conf
   APACHE_ENVVARS_FILE=/etc/sysconfig/httpd

--- a/package-scripts/occi-server/postinst
+++ b/package-scripts/occi-server/postinst
@@ -60,7 +60,7 @@ fi
 ln -sf $DEST_DIR/embedded/app/rOCCI-server/log $LINK_LOG_DIR || error_exit "Could not create a link from $LINK_LOG_DIR"
 
 # create the rocci user
-id -u rocci 2>/dev/null
+id -u rocci > /dev/null 2>&1
 if [ "$?" -ne "0" ]; then
   useradd --system --shell /bin/false rocci || error_exit "Could not create the rocci user account"
   usermod -L rocci || error_exit "Could not lock the rocci user account"

--- a/package-scripts/occi-server/postrm
+++ b/package-scripts/occi-server/postrm
@@ -47,8 +47,8 @@ fi
 if [ -f "/etc/redhat-release" ]; then
   rm -rf $DEST_DIR || error_exit "Could not unlink $DEST_DIR"
 else
-  rmdir $DEST_DIR/runtime || /bin/true
-  rmdir $DEST_DIR || /bin/true
+  rmdir $DEST_DIR/runtime > /dev/null 2>&1 || /bin/true
+  rmdir $DEST_DIR > /dev/null 2>&1 || /bin/true
 fi
 
 echo "occi-server has been uninstalled!"


### PR DESCRIPTION
- added facter to easy-up a process of determining distribution and its version
- suffix `.conf` added to apache configuration file for newer versions of apache
- apache configuration file is not accessible to others
- added option fo legacy DN format to apache configuration file for newer versions of apache
-  fixed command output redirection in {post,pre}install scripts
-  bumped version of rOCCI-server dependency to 1.1.8
